### PR TITLE
Fix issue velero 6391

### DIFF
--- a/repo/blob/s3/s3_storage.go
+++ b/repo/blob/s3/s3_storage.go
@@ -378,15 +378,6 @@ func newStorageWithCredentials(ctx context.Context, creds *credentials.Credentia
 		return nil, errors.Wrap(err, "unable to create client")
 	}
 
-	ok, err := cli.BucketExists(ctx, opt.BucketName)
-	if err != nil {
-		return nil, errors.Wrapf(err, "unable to determine if bucket %q exists", opt.BucketName)
-	}
-
-	if !ok {
-		return nil, errors.Errorf("bucket %q does not exist", opt.BucketName)
-	}
-
 	s := s3Storage{
 		Options:       *opt,
 		cli:           cli,


### PR DESCRIPTION
Skip the accessDenied error of BucketExists. As the case mentioned in the issue, the denying access to the bucket itself doesn't mean the denying access to the sub-dirs of the bucket.